### PR TITLE
Add subscriptions

### DIFF
--- a/sonar-client/lib/client.js
+++ b/sonar-client/lib/client.js
@@ -152,6 +152,20 @@ module.exports = class SonarClient {
     })
   }
 
+  async createSubscription (name, props) {
+    return this._request({
+      method: 'PUT',
+      path: [this.island, '_subscription', name],
+      data: props
+    })
+  }
+
+  async readSubscription (name) {
+    return this._request({
+      path: [this.island, '_subscription', name]
+    })
+  }
+
   _url (path) {
     if (Array.isArray(path)) path = path.join('/')
     return this.endpoint + '/' + path

--- a/sonar-dat/test/subscribe.js
+++ b/sonar-dat/test/subscribe.js
@@ -1,0 +1,68 @@
+const tape = require('tape')
+const tmp = require('temporary-directory')
+const collect = require('stream-collector')
+const { runAll } = require('./lib/util')
+
+const { IslandStore } = require('..')
+
+function prepare (t, cb) {
+  tmp((err, dir, tmpCleanup) => {
+    if (err) return cb(err)
+    const islands = new IslandStore(dir)
+    return cb(null, islands, cleanup)
+    function cleanup (cb) {
+      islands.close(() => {
+        tmpCleanup(err => {
+          t.error(err)
+          t.end()
+        })
+      })
+    }
+  })
+}
+
+tape.only('pubsub', t => {
+  prepare(t, (err, islands, cleanup) => {
+    islands.create('first', (err, island) => {
+      t.error(err, 'island created')
+
+      const records = [
+        { title: 'Hello world', body: 'so rough' },
+        { title: 'Hello moon', body: 'so dark' }
+      ]
+
+      runAll([
+        cb => {
+          const batch = records.map(value => ({ op: 'put', schema: 'core/test', value }))
+          island.db.batch(batch, (err, res) => {
+            t.error(err, 'batch ok')
+            t.equal(res.length, 2)
+            cb()
+          })
+        },
+        // TODO: Remove timeout!
+        cb => setTimeout(cb, 100),
+        cb => {
+          island.createSubscription('test', { schema: 'core/test' })
+          setTimeout(cb, 100)
+        },
+        cb => {
+          island.readSubscription('test', (err, messages) => {
+            t.error(err)
+            t.equal(messages.length, 2, 'read two subscriptions')
+            cb()
+          })
+        },
+        cb => {
+          island.readSubscription('test', (err, messages) => {
+            t.error(err)
+            t.equal(messages.length, 0, 'second read is empty')
+            cb()
+          })
+        },
+        cb => cleanup(cb)
+      ]).catch(err => t.fail(err)).then(() => t.end())
+    })
+  })
+})
+

--- a/sonar-server/routes/api.js
+++ b/sonar-server/routes/api.js
@@ -179,6 +179,21 @@ function createIslandHandlers () {
       // Query can either be a string (tantivy query) or an object (toshi json query)
       const resultStream = island.db.api.search.query(query)
       replyStream(res, resultStream)
+    },
+
+    createSubscription (req, res, next) {
+      const { island, body } = req
+      const { name } = req.params
+      island.createSubscription(name, body)
+      res.send({ name })
+    },
+
+    readSubscription (req, res, next) {
+      const { island, params: { name } } = req
+      island.readSubscription(name, (err, results) => {
+        if (err) return next(err)
+        res.send(results)
+      })
     }
   }
 }

--- a/sonar-server/routes/api.js
+++ b/sonar-server/routes/api.js
@@ -49,6 +49,10 @@ module.exports = function apiRoutes (api) {
   // TODO: This route should have the same pattern as the others.
   islandRouter.put('/_source', handlers.putSource)
 
+  // Subscriptions
+  islandRouter.put('/_subscription/:name', handlers.createSubscription)
+  islandRouter.get('/_subscription/:name', handlers.readSubscription)
+
   // Load island if in path.
   router.use('/:island', function (req, res, next) {
     const { island } = req.params


### PR DESCRIPTION
This is an initial proof of concept towards adding subscriptions. A subscription would be something between a query and a kappa view. The idea is for external processes (like the UI, or a bot) to subscribe to a specific query, receiving all history for that query plus everything new. Optionally they should be stateful so that messages are delivered only once. Because delivery may not be reliable we'd have to add a way to ack messages there.

Usecases are:

* Let the UI subscribe to records so that they don't have to be transfered twice for different queries
* Let a bot subscribe to all messages of a certain schema or with certain properties (e..g to auto process them in some way)

These two usecases don't necessarily have to use the same API but I think the basic premises are similar enough. The implementation in this PR is very inefficient, it walks the whole materialized log instead of issuing queries. I just wanted to test things out. Maybe some of this should also be discussed in a wider kappa-core context.