### PR TITLE
Improve island overview

### DIFF
--- a/sonar-client/lib/client.js
+++ b/sonar-client/lib/client.js
@@ -203,6 +203,15 @@ module.exports = class SonarClient {
     })
   }
 
+  async change (config, key) {
+    key = key || this.island
+    return this._request({
+      method: 'PATCH',
+      path: [key],
+      data: config
+    })
+  }
+
   async getDrives () {
     return this._request({
       method: 'GET',

--- a/sonar-client/lib/client.js
+++ b/sonar-client/lib/client.js
@@ -203,7 +203,7 @@ module.exports = class SonarClient {
     })
   }
 
-  async change (config, key) {
+  async updateIsland (config, key) {
     key = key || this.island
     return this._request({
       method: 'PATCH',

--- a/sonar-dat/lib/store.js
+++ b/sonar-dat/lib/store.js
@@ -159,6 +159,17 @@ module.exports = class IslandStore {
     })
   }
 
+  updateIsland (key, config) {
+    let newConfig = {};
+    if (config.share) {
+      newConfig = this.share(key)
+    } else {
+      newConfig = this.unshare(key)
+    }
+    return newConfig
+
+  }
+
   close (cb) {
     for (const island of Object.values(this.islands)) {
       island.close()

--- a/sonar-server/routes/api.js
+++ b/sonar-server/routes/api.js
@@ -22,7 +22,7 @@ module.exports = function apiRoutes (api) {
 
   const islandRouter = express.Router()
   // Change island config
-  islandRouter.patch('/', deviceHandlers.changeIsland)
+  islandRouter.patch('/', deviceHandlers.updateIsland)
   // Create command stream (websocket)
   islandRouter.ws('/commands', commandHandler)
 
@@ -119,14 +119,10 @@ function createDeviceHandlers (islands) {
         })
       })
     },
-    changeIsland (req, res, next) {
+    updateIsland (req, res, next) {
       let config = {};
       if (req.body.hasOwnProperty('share')) {
-        if (req.body.share) {
-          config = islands.share(res.locals.key) 
-        } else {
-          config = islands.unshare(res.locals.key) 
-        }
+        config = islands.updateIsland(res.locals.key, req.body) 
       }
       res.send(config)
     }

--- a/sonar-server/routes/api.js
+++ b/sonar-server/routes/api.js
@@ -21,6 +21,8 @@ module.exports = function apiRoutes (api) {
   router.put('/_create/:name', deviceHandlers.createIsland)
 
   const islandRouter = express.Router()
+  // Change island config
+  islandRouter.patch('/', deviceHandlers.changeIsland)
   // Create command stream (websocket)
   islandRouter.ws('/commands', commandHandler)
 
@@ -68,6 +70,7 @@ module.exports = function apiRoutes (api) {
   // Load island if in path.
   router.use('/:island', function (req, res, next) {
     const { island } = req.params
+    res.locals.key = island;
     if (!island) return next()
     api.islands.get(island, (err, island) => {
       if (err) return next(err)
@@ -115,6 +118,17 @@ function createDeviceHandlers (islands) {
           key: island.key.toString('hex')
         })
       })
+    },
+    changeIsland (req, res, next) {
+      let config = {};
+      if (req.body.hasOwnProperty('share')) {
+        if (req.body.share) {
+          config = islands.share(res.locals.key) 
+        } else {
+          config = islands.unshare(res.locals.key) 
+        }
+      }
+      res.send(config)
     }
   }
 }

--- a/sonar-ui/src/pages/Islands.js
+++ b/sonar-ui/src/pages/Islands.js
@@ -82,7 +82,7 @@ export default function IslandPage (props) {
                   >
                     {island.name}
                   </Link>
-                <Flex>
+                  <Flex>
                     <FormLabel p='0' mr='2' htmlFor={island.key + '-share'}>
                       Share:
                     </FormLabel>
@@ -92,15 +92,15 @@ export default function IslandPage (props) {
                       id={island.key + '-share'}
                       onChange={e => handleShareSwitch(e.target.checked, island)}
                     />
+                    <Button ml="10" variantColor="blue" onClick={e => handleToggle(island.key)}>
+                      Info
+                    <Icon
+                        name={showMoreIslands[island.key] ? 'chevron-down' : 'chevron-right'}
+                        size="24px"
+                      />
+                    </Button>
+                  </Flex>
                 </Flex>
-                  <Button variantColor="blue" onClick={e => handleToggle(island.key)}>
-                    Info
-                    <Icon 
-                      name={showMoreIslands[island.key] ? 'chevron-down' : 'chevron-right' }
-                      size="24px"
-                    />
-      </Button>
-            </Flex>
                 <Collapse isOpen={showMoreIslands[island.key]}>
                 <Flex direction='row'
                   justify='space-between'

--- a/sonar-ui/src/pages/Islands.js
+++ b/sonar-ui/src/pages/Islands.js
@@ -92,7 +92,7 @@ export default function IslandPage (props) {
                       id={island.key + '-share'}
                       onChange={e => handleShareSwitch(e.target.checked, island)}
                     />
-                    <Button ml="10" variantColor="blue" onClick={e => handleToggle(island.key)}>
+                    <Button size="sm" ml="10" variantColor="blue" onClick={e => handleToggle(island.key)}>
                       Info
                     <Icon
                         name={showMoreIslands[island.key] ? 'chevron-down' : 'chevron-right'}

--- a/sonar-ui/src/pages/Islands.js
+++ b/sonar-ui/src/pages/Islands.js
@@ -102,46 +102,36 @@ export default function IslandPage (props) {
                   </Flex>
                 </Flex>
                 <Collapse isOpen={showMoreIslands[island.key]}>
-                <Flex direction='row'
-                  justify='space-between'
-                >
-                  <Flex
-                    direction='row'
-                    justify='space-between'
-                  >
-                    <Box>Key:</Box>
-                    <Key k={island.key} mr='4' />
+                  <Flex direction="column" borderBottomWidth='1px' py='2'>
+                    <Flex direction="row" justify="space-between">
+                    <Box flexShrink='0' width={['auto', '12rem']} color='teal.400'>Key:</Box>
+                      <Box flex='1' style={{ overflowWrap: 'anywhere' }}>
+                      <Key k={island.key} mr='4' />
+                      </Box>
+                    </Flex>
+                    <Flex direction="row" justify="space-between">
+                    <Box flexShrink='0' width={['auto', '12rem']} color='teal.400'>Local key:</Box>
+                    <Box flex='1' style={{ overflowWrap: 'anywhere' }}>
+                      <Key k={island.localKey} mr='4' />
+                    </Box>
+                    </Flex>
+                    <Flex direction="row" justify="space-between">
+                    <Box flexShrink='0' width={['auto', '12rem']} color='teal.400'>Local drive:</Box>
+                    <Box flex='1' style={{ overflowWrap: 'anywhere' }}>
+                                  <Key k={island.localDrive} mr='4' />
+                    </Box>
+                      </Flex>
+                    { getNetworkInfo(island.key) && (
+                    <Flex direction="row" justify="space-between">
+                        <Box flexShrink='0' width={['auto', '12rem']} color='teal.400'>Peers:</Box>
+                        <Box flex='1' style={{overflowWrap: 'anywhere'}}>
+                          {getNetworkInfo(island.key).peers}
+                        </Box>
+                      </Flex>
+                    )
+                    }
                   </Flex>
-                  <Flex
-                    direction='row'
-                    justify='space-between'
-                  >
-                    <Box>Local key:</Box>
-                    <Key k={island.localKey} mr='4' />
-                  </Flex>
-                </Flex>
-                <Flex direction='row'
-                  justify='space-between'
-                >
-                  <Flex
-                    direction='row'
-                    justify='space-between'
-                  >
-                    <Box>Local drive:</Box>
-                    <Key k={island.localDrive} mr='4' />
-                  </Flex>
-            { getNetworkInfo(island.key) && (
-              <Flex
-                direction='row'
-                justify='space-between'
-              >
-                <Box>Peers:</Box>
-                <Box>{getNetworkInfo(island.key).peers}</Box>
-              </Flex>
-            )
-                  }
-                </Flex>
-            </Collapse>
+                </Collapse>
               </Flex>
             </PseudoBox>
           ))}

--- a/sonar-ui/src/pages/Islands.js
+++ b/sonar-ui/src/pages/Islands.js
@@ -40,17 +40,20 @@ export default function IslandPage (props) {
   if (!info && !error) return <Loading />
   if (error) return <Error error={error} />
 
-  const { islands } = info
+  const { islands, network } = info
   const selectedIsland = config.get('island')
   const selectedBg = { dark: 'gray.700', light: 'gray.100' }
 
   // let { } = useParams()
   // _hover={{ bg: 'gray.50' }}
   return (
-    <Box>
+    <Flex 
+      flex='1'
+      direction='column'
+    >
       <Heading color='teal.400'>Islands</Heading>
       { islands && (
-        <Box mb={4}>
+        <Flex direction='column' mb={4}>
           {Object.values(islands).map((island, i) => (
             <PseudoBox
               key={i}
@@ -60,41 +63,78 @@ export default function IslandPage (props) {
               p={1}
               bg={island.key === selectedIsland ? selectedBg[colorMode] : undefined}
             >
-              <Flex w={['100%', '50%']}>
-                <Link
-                  fontSize='md'
-                  variant='link'
-                  textAlign='left'
-                  color='pink.500'
-                  fontWeight='700'
-                  onClick={e => onSelectIsland(island)}
+              <Flex
+                flex='1'
+                direction='column'
+              >
+                <Flex direction='row' justify='space-between'>
+                  <Link
+                    fontSize='md'
+                    variant='link'
+                    textAlign='left'
+                    color='pink.500'
+                    fontWeight='700'
+                    onClick={e => onSelectIsland(island)}
+                  >
+                    {island.name}
+                  </Link>
+                <Flex>
+                    <FormLabel p='0' mr='2' htmlFor={island.key + '-share'}>
+                      Share:
+                    </FormLabel>
+                    <Switch
+                      size='sm'
+                      defaultIsChecked={island.share}
+                      id={island.key + '-share'}
+                      onChange={e => handleShareSwitch(e.target.checked, island)}
+                    />
+                </Flex>
+            </Flex>
+                <Flex
+                  direction='row'
+                  justify='space-between'
                 >
-                  {island.name}
-                </Link>
+                  <Box>Key:</Box>
+                  <Key k={island.key} mr='4' />
+                </Flex>
+                <Flex
+                  direction='row'
+                  justify='space-between'
+                >
+                  <Box>Local key:</Box>
+                  <Key k={island.localKey} mr='4' />
+                </Flex>
+            { getNetworkInfo(island.key) && (
+              <Flex
+              direction='row'
+              justify='space-between'
+              >
+              <Box>Peers:</Box>
+              <Box>{getNetworkInfo(island.key).peers}</Box>
               </Flex>
-              <Flex flex='1' />
-              <Flex justify='center'>
-                <Key k={island.key} flex='1' mr='4' />
-                <FormLabel p='0' mr='2' htmlFor={island.key + '-share'}>
-                  Share:
-                </FormLabel>
-                <Switch
-                  size='sm'
-                  defaultIsChecked={island.share}
-                  id={island.key + '-share'}
-                />
+            )
+            }
               </Flex>
             </PseudoBox>
           ))}
-        </Box>
+        </Flex>
       )}
       <CreateIsland onCreate={reload} />
-    </Box>
+    </Flex>
   )
 
   function onSelectIsland (island) {
     config.set('island', island.key)
     window.location.reload()
+  }
+  
+  function getNetworkInfo (key) {
+    return network.shared.find(el => el.key === key)
+  }
+
+  function handleShareSwitch (checked, island) {
+    // TODO: Change sharing for island
+    console.log(e)
   }
 }
 

--- a/sonar-ui/src/pages/Islands.js
+++ b/sonar-ui/src/pages/Islands.js
@@ -162,7 +162,6 @@ function CreateIsland (props) {
 
   return (
     <Box>
-      { message && <Alert status='info'>{message}</Alert> }
       <Form title='Create island' onSubmit={onCreate}>
         <FormField name='name' title='Local Name' />
         <FormField name='alias' title='Alias' />

--- a/sonar-ui/src/pages/Islands.js
+++ b/sonar-ui/src/pages/Islands.js
@@ -16,7 +16,8 @@ import {
   FormHelperText,
   useColorMode,
   useToast,
-  Collapse
+  Collapse,
+  Icon
 } from '@chakra-ui/core'
 import { formData } from '../lib/form'
 import useAsync from '../hooks/use-async'
@@ -93,7 +94,11 @@ export default function IslandPage (props) {
                     />
                 </Flex>
                   <Button variantColor="blue" onClick={e => handleToggle(island.key)}>
-        Info
+                    Info
+                    <Icon 
+                      name={showMoreIslands[island.key] ? 'chevron-down' : 'chevron-right' }
+                      size="24px"
+                    />
       </Button>
             </Flex>
                 <Collapse isOpen={showMoreIslands[island.key]}>
@@ -160,22 +165,13 @@ export default function IslandPage (props) {
   }
 
   function handleToggle (key) {
+    let newShowMoreIslands = {...showMoreIslands}
     if (showMoreIslands.hasOwnProperty(key)) {
-      showMoreIslands[key] = !showMoreIslands[key]
+      newShowMoreIslands[key] = !showMoreIslands[key]
     } else {
-      showMoreIslands[key] = true
+      newShowMoreIslands[key] = true
     }
-    setShowMoreIslands(showMoreIslands)
-    console.log(showMoreIslands)
-  }
-
-  function showIsland (key) {
-    if (showMoreIslands.hasOwnProperty(key) && showMoreIslands[key]) {
-      console.log('truuu dat')
-      return true
-    }
-
-    return false
+    setShowMoreIslands(newShowMoreIslands)
   }
 }
 

--- a/sonar-ui/src/pages/Islands.js
+++ b/sonar-ui/src/pages/Islands.js
@@ -90,30 +90,45 @@ export default function IslandPage (props) {
                     />
                 </Flex>
             </Flex>
-                <Flex
-                  direction='row'
-                  justify='space-between'
+            <Flex direction='row'
+                justify='space-between'
                 >
-                  <Box>Key:</Box>
-                  <Key k={island.key} mr='4' />
-                </Flex>
-                <Flex
-                  direction='row'
-                  justify='space-between'
-                >
-                  <Box>Local key:</Box>
-                  <Key k={island.localKey} mr='4' />
-                </Flex>
-            { getNetworkInfo(island.key) && (
               <Flex
-              direction='row'
-              justify='space-between'
+                direction='row'
+                justify='space-between'
               >
-              <Box>Peers:</Box>
-              <Box>{getNetworkInfo(island.key).peers}</Box>
+                <Box>Key:</Box>
+                <Key k={island.key} mr='4' />
               </Flex>
-            )
+              <Flex
+                direction='row'
+                justify='space-between'
+              >
+                <Box>Local key:</Box>
+                <Key k={island.localKey} mr='4' />
+              </Flex>
+            </Flex>
+            <Flex direction='row'
+                justify='space-between'
+                >
+              <Flex
+                direction='row'
+                justify='space-between'
+              >
+                <Box>Local drive:</Box>
+                <Key k={island.localDrive} mr='4' />
+              </Flex>
+              { getNetworkInfo(island.key) && (
+                  <Flex
+                    direction='row'
+                    justify='space-between'
+                    >
+                    <Box>Peers:</Box>
+                    <Box>{getNetworkInfo(island.key).peers}</Box>
+                  </Flex>
+                )
             }
+                </Flex>
               </Flex>
             </PseudoBox>
           ))}

--- a/sonar-ui/src/pages/Islands.js
+++ b/sonar-ui/src/pages/Islands.js
@@ -102,7 +102,7 @@ export default function IslandPage (props) {
                   </Flex>
                 </Flex>
                 <Collapse isOpen={showMoreIslands[island.key]}>
-                  <Flex direction="column" borderBottomWidth='1px' py='2'>
+                  <Flex direction="column" py='2'>
                     <Flex direction="row" justify="space-between">
                     <Box flexShrink='0' width={['auto', '12rem']} color='teal.400'>Key:</Box>
                       <Box flex='1' style={{ overflowWrap: 'anywhere' }}>

--- a/sonar-ui/src/pages/Islands.js
+++ b/sonar-ui/src/pages/Islands.js
@@ -15,7 +15,8 @@ import {
   FormErrorMessage,
   FormHelperText,
   useColorMode,
-  useToast
+  useToast,
+  Collapse
 } from '@chakra-ui/core'
 import { formData } from '../lib/form'
 import useAsync from '../hooks/use-async'
@@ -36,6 +37,7 @@ async function loadInfo () {
 export default function IslandPage (props) {
   const { colorMode } = useColorMode()
   const { data: info, error, reload } = useAsync(loadInfo)
+  const [showMoreIslands, setShowMoreIslands] = useState({})
 
   if (!info && !error) return <Loading />
   if (error) return <Error error={error} />
@@ -43,6 +45,7 @@ export default function IslandPage (props) {
   const { islands, network } = info
   const selectedIsland = config.get('island')
   const selectedBg = { dark: 'gray.700', light: 'gray.100' }
+
 
   // let { } = useParams()
   // _hover={{ bg: 'gray.50' }}
@@ -89,46 +92,51 @@ export default function IslandPage (props) {
                       onChange={e => handleShareSwitch(e.target.checked, island)}
                     />
                 </Flex>
+                  <Button variantColor="blue" onClick={e => handleToggle(island.key)}>
+        Info
+      </Button>
             </Flex>
-            <Flex direction='row'
-                justify='space-between'
+                <Collapse isOpen={showMoreIslands[island.key]}>
+                <Flex direction='row'
+                  justify='space-between'
                 >
-              <Flex
-                direction='row'
-                justify='space-between'
-              >
-                <Box>Key:</Box>
-                <Key k={island.key} mr='4' />
-              </Flex>
-              <Flex
-                direction='row'
-                justify='space-between'
-              >
-                <Box>Local key:</Box>
-                <Key k={island.localKey} mr='4' />
-              </Flex>
-            </Flex>
-            <Flex direction='row'
-                justify='space-between'
-                >
-              <Flex
-                direction='row'
-                justify='space-between'
-              >
-                <Box>Local drive:</Box>
-                <Key k={island.localDrive} mr='4' />
-              </Flex>
-              { getNetworkInfo(island.key) && (
                   <Flex
                     direction='row'
                     justify='space-between'
-                    >
-                    <Box>Peers:</Box>
-                    <Box>{getNetworkInfo(island.key).peers}</Box>
+                  >
+                    <Box>Key:</Box>
+                    <Key k={island.key} mr='4' />
                   </Flex>
-                )
-            }
+                  <Flex
+                    direction='row'
+                    justify='space-between'
+                  >
+                    <Box>Local key:</Box>
+                    <Key k={island.localKey} mr='4' />
+                  </Flex>
                 </Flex>
+                <Flex direction='row'
+                  justify='space-between'
+                >
+                  <Flex
+                    direction='row'
+                    justify='space-between'
+                  >
+                    <Box>Local drive:</Box>
+                    <Key k={island.localDrive} mr='4' />
+                  </Flex>
+            { getNetworkInfo(island.key) && (
+              <Flex
+                direction='row'
+                justify='space-between'
+              >
+                <Box>Peers:</Box>
+                <Box>{getNetworkInfo(island.key).peers}</Box>
+              </Flex>
+            )
+                  }
+                </Flex>
+            </Collapse>
               </Flex>
             </PseudoBox>
           ))}
@@ -149,6 +157,25 @@ export default function IslandPage (props) {
 
   function handleShareSwitch (checked, island) {
     client.updateIsland({ 'share': checked }, island.key)
+  }
+
+  function handleToggle (key) {
+    if (showMoreIslands.hasOwnProperty(key)) {
+      showMoreIslands[key] = !showMoreIslands[key]
+    } else {
+      showMoreIslands[key] = true
+    }
+    setShowMoreIslands(showMoreIslands)
+    console.log(showMoreIslands)
+  }
+
+  function showIsland (key) {
+    if (showMoreIslands.hasOwnProperty(key) && showMoreIslands[key]) {
+      console.log('truuu dat')
+      return true
+    }
+
+    return false
   }
 }
 

--- a/sonar-ui/src/pages/Islands.js
+++ b/sonar-ui/src/pages/Islands.js
@@ -133,8 +133,7 @@ export default function IslandPage (props) {
   }
 
   function handleShareSwitch (checked, island) {
-    // TODO: Change sharing for island
-    console.log(checked)
+    client.change({ 'share': checked }, island.key)
   }
 }
 

--- a/sonar-ui/src/pages/Islands.js
+++ b/sonar-ui/src/pages/Islands.js
@@ -134,7 +134,7 @@ export default function IslandPage (props) {
 
   function handleShareSwitch (checked, island) {
     // TODO: Change sharing for island
-    console.log(e)
+    console.log(checked)
   }
 }
 
@@ -164,7 +164,8 @@ function CreateIsland (props) {
     <Box>
       { message && <Alert status='info'>{message}</Alert> }
       <Form title='Create island' onSubmit={onCreate}>
-        <FormField name='name' title='Name' />
+        <FormField name='name' title='Local Name' />
+        <FormField name='alias' title='Alias' />
       </Form>
       <Form title='Clone island' onSubmit={onCreate}>
         <FormField name='name' title='Name' />

--- a/sonar-ui/src/pages/Islands.js
+++ b/sonar-ui/src/pages/Islands.js
@@ -148,7 +148,7 @@ export default function IslandPage (props) {
   }
 
   function handleShareSwitch (checked, island) {
-    client.change({ 'share': checked }, island.key)
+    client.updateIsland({ 'share': checked }, island.key)
   }
 }
 


### PR DESCRIPTION
The goal of this PR is to resolve #17 

It adds:
* Local key and local drive key to the overview
* Number of peers to the overview
* Share/unshare functionality
  * This introduces a new route PATCH /:islandKey which I have named change() in the client
* Adds a alias to create new island form
* Removes message above forms as we already have a notification is island creation worked or not.