### PR TITLE
Expose subscriptions

### DIFF
--- a/sonar-server/package.json
+++ b/sonar-server/package.json
@@ -24,6 +24,7 @@
     "collect-stream": "^1.2.1",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "express-sse": "^0.5.3",
     "express-ws": "^4.0.0",
     "hyperdrive-http": "^4.4.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
This replaces #9 . In the meantime I added subscription support to kappa-sparse-indexer, so we can just expose this directly.

I added three routes:
- `PUT /:island/subscription/:name` - register a new subscription
- `GET /:island/subscription/:name` - pull from current cursor position
- `GET /:island/subscription/:name/sse` - live stream the subscription with server-side events
- `POST /:island/subscription/:name/:cursor` - set the cursor for the subscription

This API has to be reviewed and possibly revised. I'd be glad for someone else to also look into this.

See #9 for usescases and more general thoughs.

- Currently, while the subscription state is persisted, a subscription has to be registered after each server restart. The idea would be that clients would always first register the subscription, then either pull in live or batch mode, and update cursor position after processing.