### PR TITLE
Add workspace manager

### DIFF
--- a/packages/client/lib/constants.js
+++ b/packages/client/lib/constants.js
@@ -1,4 +1,5 @@
 exports.DEFAULT_ENDPOINT = 'http://localhost:9191/api'
+exports.DEFAULT_WORKSPACE = 'default'
 exports.DEFAULT_COLLECTION = 'default'
 exports.SCHEMA_RESOURCE = 'sonar/resource'
 exports.METADATA_ID = 'sonar.id'

--- a/packages/client/lib/workspace.js
+++ b/packages/client/lib/workspace.js
@@ -8,8 +8,13 @@ const Bots = require('./bots')
 const Logger = require('@arsonar/common/log')
 
 const {
-  DEFAULT_ENDPOINT
+  DEFAULT_ENDPOINT,
+  DEFAULT_WORKSPACE
 } = require('./constants')
+
+function defaultWorkspace () {
+  return (process && process.env && process.env.WORKSPACE) || DEFAULT_WORKSPACE
+}
 
 class Workspace {
   /**
@@ -23,10 +28,12 @@ class Workspace {
    * @param {string} [opts.name] - The name of this client.
    */
   constructor (opts = {}) {
+    this._workspace = opts.workspace || defaultWorkspace()
     this.endpoint = opts.endpoint || DEFAULT_ENDPOINT
     if (this.endpoint.endsWith('/')) {
       this.endpoint = this.endpoint.substring(0, this.endpoint.length - 1)
     }
+    this.endpoint = this.endpoint + '/workspace/' + this._workspace
     this._collections = new Map()
     this._id = opts.id || randombytes(16).toString('hex')
     this._token = opts.token

--- a/packages/client/test/lib/create.js
+++ b/packages/client/test/lib/create.js
@@ -7,6 +7,7 @@ async function createOne (opts = {}) {
   const { server, endpoint, cleanup: cleanupServer } = await Server.createOne(opts)
   const clientOpts = opts.clientOpts || {}
   const client = new Client({ endpoint, ...clientOpts })
+  await client.createCollection('default')
   return { server, cleanup, endpoint, client }
   async function cleanup () {
     await client.close()

--- a/packages/client/test/query.js
+++ b/packages/client/test/query.js
@@ -5,6 +5,7 @@ const { createOne } = require('./lib/create')
 
 async function prepare (t) {
   const { client, cleanup } = await createOne()
+  await client.createCollection('default')
   try {
     await client.putType('doc', { fields: { title: { type: 'string' } } })
     await client.put({ type: 'doc', value: { title: 'hello world' } })

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,6 +1,9 @@
 const Workspace = require('./lib/workspace')
 const Collection = require('./lib/collection')
+const WorkspaceManager = require('./lib/workspace-manager')
+
 module.exports = {
-  Workspace,
   Collection,
+  Workspace,
+  WorkspaceManager
 }

--- a/packages/core/lib/workspace-manager.js
+++ b/packages/core/lib/workspace-manager.js
@@ -1,0 +1,82 @@
+const { NanoresourcePromise: Nanoresource } = require('nanoresource-promise/emitter')
+const { promisify } = require('util')
+const mkdirp = promisify(require('mkdirp-classic'))
+const DatSDK = require('hyper-sdk')
+const p = require('path')
+const RAF = require('random-access-file')
+const RAM = require('random-access-memory')
+const createLogger = require('@arsonar/common/log')
+
+const { defaultStoragePath } = require('./util')
+
+const Workspace = require('./workspace')
+
+module.exports = class WorkspaceManager extends Nanoresource {
+  constructor (opts = {}) {
+    super()
+    this.opts = opts
+    this.workspaces = new Map()
+    this.log = opts.log || createLogger()
+    this._storagePath = opts.storagePath || defaultStoragePath(opts)
+  }
+
+  storagePath (name) {
+    return p.join(this._storagePath, name)
+  }
+
+  async getWorkspace (name, opts) {
+    if (!name) throw new Error('Invalid workspace name')
+    if (!this.opened) await this.open()
+    let workspace
+    if (this.workspaces.has(name)) workspace = this.workspaces.get(name)
+    else workspace = this._getWorkspace(name, opts)
+    if (!workspace.opened) await workspace.open()
+    return workspace
+  }
+
+  _getWorkspace (name, opts) {
+    const storagePath = this.storagePath('workspace/' + name)
+    const workspace = new Workspace({
+      // id: deriveId(name),
+      id: name,
+      ...this.opts,
+      ...opts,
+      log: this.log,
+      sdk: this.sdk,
+      storagePath
+    })
+    this.workspaces.set(name, workspace)
+    return workspace
+  }
+
+  async _open () {
+    await mkdirp(this.storagePath(''))
+    if (!this.opts.sdk) {
+      const sdkOpts = {
+        ...this.opts,
+        swarmOpts: this.opts.swarm || this.opts.swarmOpts
+      }
+      if (this.opts.persist === false) {
+        sdkOpts.storage = RAM
+      } else {
+        sdkOpts.storage = file => RAF(this.storagePath('cores/' + file))
+      }
+      this.sdk = await DatSDK(sdkOpts)
+      this.ownSDK = true
+    } else {
+      this.sdk = this.opts.sdk
+      this.ownSDK = false
+    }
+  }
+
+  async _close () {
+    if (!this.opened) await this.open()
+    for (const workspace of this.workspaces.values()) {
+      await workspace.close()
+    }
+    if (this.ownSDK) {
+      await this.sdk.close()
+    }
+    this.emit('close')
+  }
+}

--- a/packages/core/test/basic.js
+++ b/packages/core/test/basic.js
@@ -14,7 +14,7 @@ tape('open close', async t => {
 
 tape('put and get 1', async t => {
   const { cleanup, workspace } = await createOne()
-  const collection = await workspace.openCollection('default')
+  const collection = await workspace.createCollection('default')
   await collection.putType({ name: 'doc', fields: { title: { type: 'string' } } })
   const record = await collection.put({ type: 'doc', value: { title: 'hello' } })
   t.equal(record.value.title, 'hello')
@@ -27,7 +27,7 @@ tape('put and get 1', async t => {
 
 tape('batch and query', async t => {
   const { cleanup, workspace } = await createOne()
-  const collection = await workspace.openCollection('first')
+  const collection = await workspace.createCollection('first')
   const records = [{ title: 'Hello world', body: 'so rough' },
     { title: 'Hello moon', body: 'so dark' }]
   await collection.putType({ name: 'doc', fields: { title: { type: 'string', body: { type: 'String' } } } })
@@ -66,7 +66,7 @@ tape('share and unshare workspace', async t => {
 
 tape('close collection', async t => {
   const { cleanup, workspace } = await createOne()
-  const collection = await workspace.openCollection('collection')
+  const collection = await workspace.createCollection('collection')
   t.true(collection.opened, 'opened property set')
   await collection.close()
   t.true(collection.closed, 'closed property set')
@@ -100,7 +100,7 @@ tape.skip('create collection with same name', t => {
 
 tape('query empty collection', async t => {
   const { cleanup, workspace } = await createOne()
-  const collection = await workspace.openCollection('collection')
+  const collection = await workspace.createCollection('collection')
   const result = await collection.query('search', 'anything', { sync: true })
   t.deepEquals(result, [], 'empty result')
   await cleanup()

--- a/packages/core/test/new.js
+++ b/packages/core/test/new.js
@@ -8,7 +8,7 @@ const createNative = require('hyper-sdk/test/lib/native')
 const createHyperspace = require('hyper-sdk/test/lib/hyperspace')
 const createMixed = require('hyper-sdk/test/lib/mixed')
 
-const { Workspace, Collection } = require('..')
+const { Workspace } = require('..')
 
 // Prepare and patch tape
 Error.stackTraceLimit = 50
@@ -89,7 +89,7 @@ function runTests (create) {
   test('basic put and get', async t => {
     // try {
     const [w1, cleanup] = await create(1)
-    const c1 = w1.Collection('default')
+    const c1 = await w1.createCollection('default')
     await setup(c1)
     const res = await c1.query('records', { type: 'doc' })
     t.equal(res.length, 1)
@@ -110,10 +110,10 @@ function runTests (create) {
   test('basic replication', { timeout: 5000 }, async t => {
     const [w1, w2, cleanup] = await create(2)
 
-    const c1 = w1.Collection('default')
+    const c1 = await w1.createCollection('default')
     await setup(c1)
 
-    const c2 = w2.Collection(c1.key)
+    const c2 = await w2.createCollection(c1.key)
     await c2.open()
     await c2.sync()
 
@@ -146,7 +146,7 @@ function runTests (create) {
 
   test('open and close and open', async t => {
     let [workspace, cleanup] = await create(1, { persist: true })
-    let col = workspace.Collection('first')
+    let col = await workspace.createCollection('first')
     await col.ready()
     await col.putType(DOC_SPEC)
     const type1 = col.schema.getType('doc')
@@ -160,7 +160,7 @@ function runTests (create) {
 
     workspace = new Workspace({ storagePath, sdk })
     await workspace.ready()
-    col = workspace.Collection('first')
+    col = await workspace.createCollection('first')
     await col.ready()
     const key = col.key
     const type2 = col.schema.getType('doc')
@@ -171,7 +171,7 @@ function runTests (create) {
 
     workspace = new Workspace({ storagePath, sdk })
     await workspace.ready()
-    col = workspace.Collection(key)
+    col = await workspace.openCollection(key)
     await col.ready()
     const type3 = col.schema.getType('doc')
     t.equal(type3.name, 'doc')
@@ -183,7 +183,7 @@ function runTests (create) {
 
   test('sonar fs', async t => {
     const [workspace, cleanup] = await create(1, { persist: true })
-    const collection = workspace.Collection('default')
+    const collection = await workspace.createCollection('default')
     await collection.open()
     const feeds = await collection.get({ type: 'sonar/feed' })
     const drives = feeds.filter(record => record.value.type === 'hyperdrive')

--- a/packages/plugin-relations/test/relations.js
+++ b/packages/plugin-relations/test/relations.js
@@ -16,7 +16,7 @@ tape('relations', async t => {
     }
   }
 
-  const collection = await workspace.openCollection('default')
+  const collection = await workspace.createCollection('default')
   await collection.putType(type)
   await collection.put({
     id: 'alice',

--- a/packages/plugin-search/src/query.js
+++ b/packages/plugin-search/src/query.js
@@ -40,6 +40,7 @@ function executeQuery (indexManager, query, indexName) {
       stream.push(null)
       debug('query with %d results (time %s, index %s, query %o)', results.length, time(), index.name, query)
     } catch (err) {
+      console.error('err', err)
       stream.destroy(err)
     }
   }

--- a/packages/server/handlers/collection-handler.js
+++ b/packages/server/handlers/collection-handler.js
@@ -7,19 +7,20 @@ const AH = require('../lib/async-handler')
 
 const createFsRouter = require('./fs')
 
-module.exports = function createCollectionRoutes (workspace) {
+module.exports = function createCollectionRoutes () {
   const router = express.Router()
 
   router.use('/:collection', AH(async (req, res, next) => {
     const { collection: keyOrName } = req.params
+
     if (!keyOrName) return next()
     // TODO: Implement auth :-)
-    const collection = await workspace.openCollection(keyOrName)
+    const collection = await req.workspace.openCollection(keyOrName)
     req.collection = collection
     next()
   }))
 
-  router.use('/:collection/fs', createFsRouter(workspace))
+  router.use('/:collection/fs', createFsRouter())
 
   router.get('/:collection', AH(async (req, res, next) => {
     return req.collection.status()
@@ -204,7 +205,7 @@ module.exports = function createCollectionRoutes (workspace) {
     let pending = drives.length
     if (!drives.length) return res.send([])
     drives.forEach(driveInfo => {
-      collection.fs.get(driveInfo.key, (err, drive) => {
+      collection.drive(driveInfo.key, (err, drive) => {
         if (err) driveInfo.error = err.message
         else {
           driveInfo.writable = drive.writable

--- a/packages/server/handlers/device-handler.js
+++ b/packages/server/handlers/device-handler.js
@@ -1,16 +1,16 @@
 const AH = require('../lib/async-handler')
 
-module.exports = function createDeviceHandler (workspace) {
+module.exports = function createDeviceHandler () {
   return {
     info: AH(async (req, res, next) => {
-      const status = await workspace.status()
+      const status = await req.workspace.status()
       return status
     }),
 
     createCollection: AH(async (req, res, next) => {
       const { name, key, alias } = req.body
       const opts = { alias, name }
-      const collection = await workspace.createCollection(key || name, opts)
+      const collection = await req.workspace.createCollection(key || name, opts)
       return collection.status()
     })
   }

--- a/packages/server/handlers/fs.js
+++ b/packages/server/handlers/fs.js
@@ -7,7 +7,7 @@ const express = require('express')
 const speedometer = require('speedometer')
 const debug = require('debug')('sonar-server:fs')
 
-module.exports = function hyperdriveMiddleware (workspace) {
+module.exports = function hyperdriveMiddleware () {
   const router = express.Router()
 
   router.use('/:drive', function (req, res, next) {

--- a/packages/server/launch.js
+++ b/packages/server/launch.js
@@ -4,7 +4,12 @@ const options = require('./bin/lib/options')
 const args = require('yargs').options(options).argv
 
 const server = new Server(args)
-server.start(() => {
+server.start((err) => {
+  if (err) {
+    console.error(err)
+    server.api.log.error(err)
+    process.exit(1)
+  }
   const address = `http://${server.hostname}:${server.port}`
   server.api.log.info(`API is listening on ${address}`)
   const code = server.api.auth.getRootAccessCode()

--- a/packages/server/test/basic.js
+++ b/packages/server/test/basic.js
@@ -11,7 +11,8 @@ tape('basic', async t => {
         defaultViews: false
       }
     }
-    const { endpoint, cleanup } = await createOne(opts)
+    let { endpoint, cleanup } = await createOne(opts)
+    endpoint += '/workspace/default'
 
     const created = await fetchJSON(`${endpoint}/collection`, {
       method: 'POST',


### PR DESCRIPTION
This is a breaking change to storage and HTTP API!

- core: Add WorkspaceManager class to manage workspaces
- core: Allow a different local writer per collection per workspace
- server: All routes have a `/workspace/:workspace` prefix now
- server: Workspace middleware to set correct workspace on requests
- client: New workspace option, with default value
- fix tests